### PR TITLE
Update GitHub actions, which use Node.js 20

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -19,13 +19,13 @@ jobs:
           token: ${{ secrets.GH_PAGES_DEPLOY_BOT_PAT }}
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1.2.0
+        uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: "latest"
       - run: mdbook build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.9.3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           personal_token: ${{ secrets.GH_PAGES_DEPLOY_BOT_PAT }}

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_PAGES_DEPLOY_BOT_PAT }}
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@v2.0.0
         with:
           mdbook-version: "latest"
       - run: mdbook build

--- a/.github/workflows/deploy-release-pdf.yaml
+++ b/.github/workflows/deploy-release-pdf.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@v2.0.0
         with:
           mdbook-version: "latest"
       - run: cargo install mdbook-pdf

--- a/.github/workflows/deploy-release-pdf.yaml
+++ b/.github/workflows/deploy-release-pdf.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1.2.0
+        uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: "latest"
       - run: cargo install mdbook-pdf
@@ -25,7 +25,7 @@ jobs:
         run: mv book/pdf/output.pdf book/pdf/f4e_manual.pdf
 
       - name: Release PDF
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           artifactErrorsFailBuild: true
           artifacts: "book/pdf/f4e_manual.pdf"


### PR DESCRIPTION
Node.js 16 actions are deprecated. Update GitHub actions, which use Node.js 20.
* bpeaceiris/actions-mdbook@v1.2.0 -> v2.0.0
* peaceiris/actions-gh-pages@v3.9.3 -> v4.0.0
* ncipollo/release-action@v1.13.0 -> v1.14.0