### PR TITLE
Fix a wording error

### DIFF
--- a/src/cockpit/pilot/weapon_management.md
+++ b/src/cockpit/pilot/weapon_management.md
@@ -281,7 +281,7 @@ right pair is linked to stations 8L and 8R.
 ![Radar Missile Power Switch](../../img/pilot_radar_missile_power_switch.jpg)
 
 The Radar Missile Power Switch provides power to the klystron continuous wave
-(CW) for emitter responsible guidance signals. This also powers the Sparrow
+(CW) emitter responsible for guidance signals. This also powers the Sparrow
 tuning drive which is responsible for tuning the Sparrows to the correct
 continuous wave carrier frequency for guidance.
 


### PR DESCRIPTION
A simple mistake in the wording of the docs.