### PR TITLE
a11y: use accessible symbols in AIM-7 and AIM-9 tables

### DIFF
--- a/src/stores/air_to_air/aim_7.md
+++ b/src/stores/air_to_air/aim_7.md
@@ -145,14 +145,14 @@ Phantom:
 | 7M   | The M was the first inverse mono-pulse Sparrow providing increased tracking precision, it also has improved motor performance and electronics, including improved clutter and countermeasure rejection. The M like all Sparrows can also guide using continuous wave, at a degraded tracking precision.                                                                                                                                                                                                 |
 
 Below is a very basic comparative summary of each Sparrow's performance in some
-general areas, whereas 🟩 means _good_, 🟨 _fair_ and 🟥 _poor_.
+general areas, whereas ✔️ means _good_, ⚠️ _fair_ and ❌ _poor_.
 
 | Type    | Seeker | Range | Dogfight | Countermeasure Resist / Clutter Rejection |
 | ------- | ------ | ----- | -------- | ----------------------------------------- |
-| AIM-7E  | 🟥     | 🟨    | ❌       | 🟥                                        |
-| AIM-7E2 | 🟥     | 🟥    | ✅       | 🟥                                        |
-| AIM-7F  | 🟨     | 🟩    | ✅       | 🟨                                        |
-| AIM-7M  | 🟩     | 🟩    | ✅       | 🟩                                        |
+| AIM-7E  | ❌     | ⚠️    | ❌       | ❌                                        |
+| AIM-7E2 | ❌     | ❌    | ✔️       | ❌                                        |
+| AIM-7F  | ⚠️     | ✔️    | ✔️       | ⚠️                                        |
+| AIM-7M  | ✔️     | ✔️    | ✔️       | ✔️                                        |
 
 > 💡 Technically, the E2 has the same maximal range than the E.
 > However, due to its maneuvering-behavior, that range lessens for anything but a dead straight shot.

--- a/src/stores/air_to_air/aim_7.md
+++ b/src/stores/air_to_air/aim_7.md
@@ -145,14 +145,14 @@ Phantom:
 | 7M   | The M was the first inverse mono-pulse Sparrow providing increased tracking precision, it also has improved motor performance and electronics, including improved clutter and countermeasure rejection. The M like all Sparrows can also guide using continuous wave, at a degraded tracking precision.                                                                                                                                                                                                 |
 
 Below is a very basic comparative summary of each Sparrow's performance in some
-general areas, whereas ✔️ means _good_, ⚠️ _fair_ and ❌ _poor_.
+general areas, whereas <span style="color:green">▲</span> means _good_, <span style="color:yellow">⬤</span> _fair_ and <span style="color:red">▼</span> _poor_.
 
 | Type    | Seeker | Range | Dogfight | Countermeasure Resist / Clutter Rejection |
 | ------- | ------ | ----- | -------- | ----------------------------------------- |
-| AIM-7E  | ❌     | ⚠️    | ❌       | ❌                                        |
-| AIM-7E2 | ❌     | ❌    | ✔️       | ❌                                        |
-| AIM-7F  | ⚠️     | ✔️    | ✔️       | ⚠️                                        |
-| AIM-7M  | ✔️     | ✔️    | ✔️       | ✔️                                        |
+| AIM-7E  | <span style="color:red">▼</span>     | <span style="color:yellow">⬤</span>    | <span style="color:red">▼</span>       | <span style="color:red">▼</span>                                        |
+| AIM-7E2 | <span style="color:red">▼</span>     | <span style="color:red">▼</span>    | <span style="color:green">▲</span>       | <span style="color:red">▼</span>                                        |
+| AIM-7F  | <span style="color:yellow">⬤</span>     | <span style="color:green">▲</span>    | <span style="color:green">▲</span>       | <span style="color:yellow">⬤</span>                                        |
+| AIM-7M  | <span style="color:green">▲</span>     | <span style="color:green">▲</span>    | <span style="color:green">▲</span>       | <span style="color:green">▲</span>                                        |
 
 > 💡 Technically, the E2 has the same maximal range than the E.
 > However, due to its maneuvering-behavior, that range lessens for anything but a dead straight shot.

--- a/src/stores/air_to_air/aim_7.md
+++ b/src/stores/air_to_air/aim_7.md
@@ -138,21 +138,22 @@ The following variants of the AIM-7 family are available for this variant of the
 Phantom:
 
 | Type | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ---- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 7E   | The E variant was an early version of the Sparrow missile, entering service in the 1960s, which uses proportional navigation and Semi Active Radar Homing to guide.                                                                                                                                                                                                                                                                                                                                     |
 | 7E2  | Changes were made to improve the performance in close range dogfight situations, at the expense of energy retention in longer ranged engagements. Fuzing time is also reduced allowing for proper fuzing in close engagements.                                                                                                                                                                                                                                                                          |
 | 7F   | The F Sparrow was upgraded to be solid state, have a higher performance two stage motor (boost and sustainer) and have improved electronics including the ability to coast targets through the main lobe clutter and altitude lines. These changes also make the seeker able to detect targets from further range and with increased countermeasure resistance and track using both continuous wave and pulse doppler guidance signals unlike the E, E2 and E3 which can only guide on continuous wave. |
 | 7M   | The M was the first inverse mono-pulse Sparrow providing increased tracking precision, it also has improved motor performance and electronics, including improved clutter and countermeasure rejection. The M like all Sparrows can also guide using continuous wave, at a degraded tracking precision.                                                                                                                                                                                                 |
 
 Below is a very basic comparative summary of each Sparrow's performance in some
-general areas, whereas <span style="color:green">▲</span> means _good_, <span style="color:yellow">⬤</span> _fair_ and <span style="color:red">▼</span> _poor_.
+general areas, whereas 🟢 means _good_, 🟨 _fair_ and 🔺 _poor_.
 
 | Type    | Seeker | Range | Dogfight | Countermeasure Resist / Clutter Rejection |
 | ------- | ------ | ----- | -------- | ----------------------------------------- |
-| AIM-7E  | <span style="color:red">▼</span>     | <span style="color:yellow">⬤</span>    | <span style="color:red">▼</span>       | <span style="color:red">▼</span>                                        |
-| AIM-7E2 | <span style="color:red">▼</span>     | <span style="color:red">▼</span>    | <span style="color:green">▲</span>       | <span style="color:red">▼</span>                                        |
-| AIM-7F  | <span style="color:yellow">⬤</span>     | <span style="color:green">▲</span>    | <span style="color:green">▲</span>       | <span style="color:yellow">⬤</span>                                        |
-| AIM-7M  | <span style="color:green">▲</span>     | <span style="color:green">▲</span>    | <span style="color:green">▲</span>       | <span style="color:green">▲</span>                                        |
+| AIM-7E  | 🔺     | 🟨    | 🔺       | 🔺                                        |
+| AIM-7E2 | 🔺     | 🔺    | 🟢       | 🔺                                        |
+| AIM-7F  | 🟨     | 🟢    | 🟢       | 🟨                                        |
+| AIM-7M  | 🟢     | 🟢    | 🟢       | 🟢                                        |
 
-> 💡 Technically, the E2 has the same maximal range than the E.
-> However, due to its maneuvering-behavior, that range lessens for anything but a dead straight shot.
+> 💡 Technically, the E2 has the same maximal range than the E. However, due to
+> its maneuvering-behavior, that range lessens for anything but a dead straight
+> shot.

--- a/src/stores/air_to_air/aim_9.md
+++ b/src/stores/air_to_air/aim_9.md
@@ -71,19 +71,19 @@ Phantom:
 | Captive M | Non-functional version used for training and testing purposes.                                                                                                                                                       |
 
 Below is a basic comparative summary of each Sidewinder's performance in some
-general areas, whereas <span style="color:green">▲</span> means _good_, <span style="color:yellow">⬤</span> _fair_ and <span style="color:red">▼</span> _poor_.
+general areas, whereas 🟢 means _good_, 🟨 _fair_ and 🔺 _poor_.
 
 | Type      | Lock-Tone | Uncage | Aspect | Maneuverability | CM Resist | Motor |
 | --------- | --------- | ------ | ------ | --------------- | --------- | ----- |
-| B         | <span style="color:red">▼</span>        | <span style="color:red">▼</span>     | Rear   | <span style="color:red">▼</span>            | <span style="color:red">▼</span>        | <span style="color:red">▼</span>    |
-| J         | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:red">▼</span>    |
-| JULI      | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:yellow">⬤</span>            | <span style="color:green">▲</span>        | <span style="color:yellow">⬤</span>    |
-| L         | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
-| M         | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
-| P         | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:red">▼</span>    |
-| P-3       | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:yellow">⬤</span>    |
-| P-5       | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:yellow">⬤</span>            | <span style="color:green">▲</span>        | <span style="color:yellow">⬤</span>    |
-| Captive M | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
+| B         | 🔺        | 🔺     | Rear   | 🔺              | 🔺        | 🔺    |
+| J         | 🔺        | 🟢     | Rear   | 🟨              | 🟨        | 🔺    |
+| JULI      | 🟢        | 🟢     | All    | 🟨              | 🟢        | 🟨    |
+| L         | 🟢        | 🟢     | All    | 🟢              | 🟢        | 🟢    |
+| M         | 🟢        | 🟢     | All    | 🟢              | 🟢        | 🟢    |
+| P         | 🔺        | 🟢     | Rear   | 🟨              | 🟨        | 🔺    |
+| P-3       | 🔺        | 🟢     | Rear   | 🟨              | 🟨        | 🟨    |
+| P-5       | 🟢        | 🟢     | All    | 🟨              | 🟢        | 🟨    |
+| Captive M | 🟢        | 🟢     | All    | 🟢              | 🟢        | 🟢    |
 
 Some variants have a null-seeker. These missiles do not produce a tone when
 fully aligned with a target. This can lead to confusion, thinking the missile

--- a/src/stores/air_to_air/aim_9.md
+++ b/src/stores/air_to_air/aim_9.md
@@ -71,19 +71,19 @@ Phantom:
 | Captive M | Non-functional version used for training and testing purposes.                                                                                                                                                       |
 
 Below is a basic comparative summary of each Sidewinder's performance in some
-general areas, whereas 🟩 means _good_, 🟨 _fair_ and 🟥 _poor_.
+general areas, whereas ✔️ means _good_, ⚠️ _fair_ and ❌ _poor_.
 
 | Type      | Lock-Tone | Uncage | Aspect | Maneuverability | CM Resist | Motor |
 | --------- | --------- | ------ | ------ | --------------- | --------- | ----- |
-| B         | ❌        | ❌     | Rear   | 🟥              | 🟥        | 🟥    |
-| J         | ❌        | ✅     | Rear   | 🟨              | 🟨        | 🟥    |
-| JULI      | ✅        | ✅     | All    | 🟨              | 🟩        | 🟨    |
-| L         | ✅        | ✅     | All    | 🟩              | 🟩        | 🟩    |
-| M         | ✅        | ✅     | All    | 🟩              | 🟩        | 🟩    |
-| P         | ❌        | ✅     | Rear   | 🟨              | 🟨        | 🟥    |
-| P-3       | ❌        | ✅     | Rear   | 🟨              | 🟨        | 🟨    |
-| P-5       | ✅        | ✅     | All    | 🟨              | 🟩        | 🟨    |
-| Captive M | ✅        | ✅     | All    | 🟩              | 🟩        | 🟩    |
+| B         | ❌        | ❌     | Rear   | ❌            | ❌        | ❌    |
+| J         | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ❌    |
+| JULI      | ✔️        | ✔️     | All    | ⚠️            | ✔️        | ⚠️    |
+| L         | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
+| M         | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
+| P         | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ❌    |
+| P-3       | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ⚠️    |
+| P-5       | ✔️        | ✔️     | All    | ⚠️            | ✔️        | ⚠️    |
+| Captive M | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
 
 Some variants have a null-seeker. These missiles do not produce a tone when
 fully aligned with a target. This can lead to confusion, thinking the missile

--- a/src/stores/air_to_air/aim_9.md
+++ b/src/stores/air_to_air/aim_9.md
@@ -71,19 +71,19 @@ Phantom:
 | Captive M | Non-functional version used for training and testing purposes.                                                                                                                                                       |
 
 Below is a basic comparative summary of each Sidewinder's performance in some
-general areas, whereas ✔️ means _good_, ⚠️ _fair_ and ❌ _poor_.
+general areas, whereas <span style="color:green">▲</span> means _good_, <span style="color:yellow">⬤</span> _fair_ and <span style="color:red">▼</span> _poor_.
 
 | Type      | Lock-Tone | Uncage | Aspect | Maneuverability | CM Resist | Motor |
 | --------- | --------- | ------ | ------ | --------------- | --------- | ----- |
-| B         | ❌        | ❌     | Rear   | ❌            | ❌        | ❌    |
-| J         | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ❌    |
-| JULI      | ✔️        | ✔️     | All    | ⚠️            | ✔️        | ⚠️    |
-| L         | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
-| M         | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
-| P         | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ❌    |
-| P-3       | ❌        | ✔️     | Rear   | ⚠️            | ⚠️        | ⚠️    |
-| P-5       | ✔️        | ✔️     | All    | ⚠️            | ✔️        | ⚠️    |
-| Captive M | ✔️        | ✔️     | All    | ✔️            | ✔️        | ✔️    |
+| B         | <span style="color:red">▼</span>        | <span style="color:red">▼</span>     | Rear   | <span style="color:red">▼</span>            | <span style="color:red">▼</span>        | <span style="color:red">▼</span>    |
+| J         | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:red">▼</span>    |
+| JULI      | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:yellow">⬤</span>            | <span style="color:green">▲</span>        | <span style="color:yellow">⬤</span>    |
+| L         | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
+| M         | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
+| P         | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:red">▼</span>    |
+| P-3       | <span style="color:red">▼</span>        | <span style="color:green">▲</span>     | Rear   | <span style="color:yellow">⬤</span>            | <span style="color:yellow">⬤</span>        | <span style="color:yellow">⬤</span>    |
+| P-5       | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:yellow">⬤</span>            | <span style="color:green">▲</span>        | <span style="color:yellow">⬤</span>    |
+| Captive M | <span style="color:green">▲</span>        | <span style="color:green">▲</span>     | All    | <span style="color:green">▲</span>            | <span style="color:green">▲</span>        | <span style="color:green">▲</span>    |
 
 Some variants have a null-seeker. These missiles do not produce a tone when
 fully aligned with a target. This can lead to confusion, thinking the missile


### PR DESCRIPTION
The symbols 🟩 and 🟥 are difficult for people with color vision deficiency to distinguish. This PR replaces the symbols 🟩🟨🟥 with ✔️⚠️❌ which communicate using color _and_ shape.