### PR TITLE
Update aim_7.md

### DIFF
--- a/src/procedures/aim_7.md
+++ b/src/procedures/aim_7.md
@@ -1,5 +1,13 @@
 # AIM-7 Missile
 
+The checklists below outline the required cockpit procedures 
+for the employment of the AIM-7 Sparrow missile. 
+In order to have a better understanding of the missile 
+employment methods, launch sequence and its variants 
+please refer to the section [4.2.1 AIM-7 Sparrow](../../stores/air_to_air/aim_7.md)
+of this manual.
+
+
 ## AIM-7E Tuneup
 
 | Step | System                     | Action         |

--- a/src/procedures/aim_7.md
+++ b/src/procedures/aim_7.md
@@ -1,12 +1,9 @@
 # AIM-7 Missile
 
-The checklists below outline the required cockpit procedures 
-for the employment of the AIM-7 Sparrow missile. 
-In order to have a better understanding of the missile 
-employment methods, launch sequence and its variants 
-please refer to the section [4.2.1 AIM-7 Sparrow](../../stores/air_to_air/aim_7.md)
-of this manual.
-
+The checklists below outline the required cockpit procedures for the employment
+of the AIM-7 Sparrow missile. In order to have a better understanding of the
+missile employment methods, launch sequence and its variants please refer to
+section [4.2.1 AIM-7 Sparrow](../stores/air_to_air/aim_7.md).
 
 ## AIM-7E Tuneup
 


### PR DESCRIPTION
Small text with  a link at the header of the page to provide more context for the user on how to employ the AIM-7 missile.
I followed the format of the links in the AIM-7 Sparrow page in order to refer to an internal link, not an external one as I did before for the Shrike missile. 