### PR TITLE
Updated for Shrike tables for 2.9.19

### DIFF
--- a/src/stores/air_to_ground/missiles/shrike.md
+++ b/src/stores/air_to_ground/missiles/shrike.md
@@ -266,18 +266,18 @@ General Key:
 
 ##### Warsaw Pact land-based SAM and EWR system radars
 
-| Seeker       |  SA-2   | SA-3 | SA-5 | SA-6 | SA-8 |    SA-10     | SA-11 | SA-13 |   SA-15   | SA-19 | EWR  |
-| ------------ | :-----: | :--: | :--: | :--: | :--: | :----------: | :---: | :---: | :-------: | :---: | :--: |
-| Mk 22        | (TR)/RF |      |      |      |      |              |       | (TR)  |    TR     |       | (DE) |
-| Mk 23        |   RF    |      | (TS) |      |      | (TS)/(BB)/CS |  SR   |  TR   |   (SR)    | (SR)  |      |
-| Mk 24 Mod 5  |   RF    |      | (TS) |      |      |     (TS)     |       |  TR   |           |  SR   |      |
-| Mk 24 Mod 34 |   RF    |      | (TS) |      |      | (TS)/(BB)/CS |       |  TR   |           |  SR   |      |
-| Mk 25        | (TR)/RF |      |      |      |      |              |       | (TR)  |    TR     |       | (DE) |
-| Mk 36        |   RF    | (TR) |      | (TR) |      |      TR      | (TR)  |  TR   |           |       |      |
-| Mk 37        | (FF)/RF | (FF) | (FF) |  SR  |  SR  |              |       |  TR   |           |       |      |
-| Mk 49 Mod 0  |   RF    | (TR) | (TR) | (TR) |      |     (TR)     | (TR)  |  TR   |           |       |      |
-| Mk 49 Mod 1  |   RF    | (TR) | (TR) | (TR) |      |     (TR)     | (TR)  |  TR   |           |       |      |
-| Mk 50        | (TR)/RF |      | (TS) |      |      | (TS)/(BB)/CS |  SR   | (TR)  | (SR)/(TR) | (SR)  | (DE) |
+| Seeker       |  SA-2   | SA-3 | SA-5 | SA-6 | SA-8 |    SA-10     | SA-11 | SA-13 | SA-15 (Tor-M1) | SA-15 (Tor-M2) | SA-19 | SA-22 | EWR  |
+| ------------ | :-----: | :--: | :--: | :--: | :--: | :----------: | :---: | :---: | :------------: | :------------: | :---: | :---: | :--: |
+| Mk 22        | (TR)/RF |      |      |      |      |              |       | (TR)  |       TR       |                |       |       | (DE) |
+| Mk 23        |   RF    |      | (TS) |      |      | (TS)/(BB)/CS |  SR   |  TR   |      (SR)      |       SR       | (SR)  |  SR   |      |
+| Mk 24 Mod 5  |   RF    |      | (TS) |      |      |     (TS)     |       |  TR   |                |       SR       |  SR   |  SR   |      |
+| Mk 24 Mod 34 |   RF    |      | (TS) |      |      | (TS)/(BB)/CS |       |  TR   |                |       SR       |  SR   |  SR   |      |
+| Mk 25        | (TR)/RF |      |      |      |      |              |       | (TR)  |       TR       |                |       |       | (DE) |
+| Mk 36        |   RF    | (TR) |      | (TR) |      |      TR      | (TR)  |  TR   |                |                |       |  TR   |      |
+| Mk 37        | (FF)/RF | (FF) | (FF) |  SR  |  SR  |              |       |  TR   |                |                |       |       |      |
+| Mk 49 Mod 0  |   RF    | (TR) | (TR) | (TR) |      |     (TR)     | (TR)  |  TR   |                |                |       |  TR   |      |
+| Mk 49 Mod 1  |   RF    | (TR) | (TR) | (TR) |      |     (TR)     | (TR)  |  TR   |                |                |       |  TR   |      |
+| Mk 50        | (TR)/RF |      | (TS) |      |      | (TS)/(BB)/CS |  SR   | (TR)  |   (SR)/(TR)    |      (SR)      | (SR)  | (SR)  | (DE) |
 
 > 💡 The SA-2/3/5 all can use the same Flat Face search radar with the SA-5 having the option of
 > using the Tin Shield as a search radar as well.
@@ -320,18 +320,18 @@ General Key:
 
 ##### NATO land-based SAM system radars and EWRs
 
-| Seeker       | Hawk  | Patriot | Rapier | Roland | NASAMS |
-| ------------ | :---: | :-----: | :----: | :----: | :----: |
-| Mk 22        |  TR   |   STR   |   SR   |        |        |
-| Mk 23        |  TR   |         |   SR   |        |        |
-| Mk 24 Mod 5  |  TR   |         |   SR   |        |        |
-| Mk 24 Mod 34 |  TR   |         |   SR   |        |        |
-| Mk 25        |  TR   |   STR   |  (SR)  |        |        |
-| Mk 36        |  TR   |         |   SR   |   TR   |  (SR)  |
-| Mk 37        | SR/TR |         |   SR   |        |        |
-| Mk 49 Mod 0  |  TR   |         |   SR   |        |        |
-| Mk 49 Mod 1  |  TR   |         |   SR   |        |        |
-| Mk 50        |  TR   |   STR   |  (SR)  |        |        |
+| Seeker       | Hawk  | Patriot | Rapier | Roland | NASAMS | IRIS-T SLM |
+| ------------ | :---: | :-----: | :----: | :----: | :----: | :--------: |
+| Mk 22        |  TR   |   STR   |   SR   |        |        |    STR     |
+| Mk 23        |  TR   |         |   SR   |        |        |            |
+| Mk 24 Mod 5  |  TR   |         |   SR   |        |        |            |
+| Mk 24 Mod 34 |  TR   |         |   SR   |        |        |            |
+| Mk 25        |  TR   |   STR   |  (SR)  |        |        |    STR     |
+| Mk 36        |  TR   |         |   SR   |   TR   |  (SR)  |            |
+| Mk 37        | SR/TR |         |   SR   |        |        |            |
+| Mk 49 Mod 0  |  TR   |         |   SR   |        |        |            |
+| Mk 49 Mod 1  |  TR   |         |   SR   |        |        |            |
+| Mk 50        |  TR   |   STR   |  (SR)  |        |        |    STR     |
 
 #### Naval Threats
 
@@ -339,18 +339,18 @@ General Key:
 
 ##### Soviet Naval Threats
 
-| Seeker       |   Kirov   |   Slava   | Kuznetsov | Molniya |  Grisha   |  Krivak   | Neustrashimy | Ropucha |
-| ------------ | :-------: | :-------: | :-------: | :-----: | :-------: | :-------: | :----------: | :-----: |
-| Mk 22        |    TR     |   (TR)    |    TR     |         |    TR     |    TR     |     (TR)     |         |
-| Mk 23        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |   (TR)    |   (TR)    |  (SR)/(TR)   |         |
-| Mk 24 Mod 5  |   SR/TR   |    TR     |   SR/TR   |  SR/TR  |    TR     |   (TR)    |  (SR)/(TR)   |         |
-| Mk 24 Mod 34 |   (TR)    |   (TR)    |   (TR)    |         |    TR     |   (TR)    |      TR      |         |
-| Mk 25        |    TR     |    TR     |    TR     |         |    TR     |    TR     |      TR      |         |
-| Mk 36        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |    TR     |   (TR)    |  (SR)/(TR)   |         |
-| Mk 37        |    TR     |    TR     |    TR     |         |    TR     |    TR     |      TR      |         |
-| Mk 49 Mod 0  |   (TR)    |   (TR)    |   (TR)    |         | (SR)/(TR) | (SR)/(TR) |     (TR)     |         |
-| Mk 49 Mod 1  |   (TR)    |   (TR)    |   (TR)    |         | (SR)/(TR) | (SR)/(TR) |     (TR)     |         |
-| Mk 50        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |   (TR)    |   (TR)    |  (SR)/(TR)   |         |
+| Seeker       |   Kirov   |   Slava   | Kuznetsov | Molniya |  Grisha   |  Krivak   | Neustrashimy | Ropucha | Project 22160 | Project 22160 with Tor-M2M |
+| ------------ | :-------: | :-------: | :-------: | :-----: | :-------: | :-------: | :----------: | :-----: | :-----------: | :------------------------: |
+| Mk 22        |    TR     |   (TR)    |    TR     |         |    TR     |    TR     |     (TR)     |         |               |                            |
+| Mk 23        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |   (TR)    |   (TR)    |  (SR)/(TR)   |         |               |             SR             |
+| Mk 24 Mod 5  |   SR/TR   |    TR     |   SR/TR   |  SR/TR  |    TR     |   (TR)    |  (SR)/(TR)   |         |               |             SR             |
+| Mk 24 Mod 34 |   (TR)    |   (TR)    |   (TR)    |         |    TR     |   (TR)    |      TR      |         |               |             SR             |
+| Mk 25        |    TR     |    TR     |    TR     |         |    TR     |    TR     |      TR      |         |               |                            |
+| Mk 36        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |    TR     |   (TR)    |  (SR)/(TR)   |         |     SR/TR     |           SR/TR            |
+| Mk 37        |    TR     |    TR     |    TR     |         |    TR     |    TR     |      TR      |         |               |                            |
+| Mk 49 Mod 0  |   (TR)    |   (TR)    |   (TR)    |         | (SR)/(TR) | (SR)/(TR) |     (TR)     |         |     SR/TR     |           SR/TR            |
+| Mk 49 Mod 1  |   (TR)    |   (TR)    |   (TR)    |         | (SR)/(TR) | (SR)/(TR) |     (TR)     |         |     SR/TR     |           SR/TR            |
+| Mk 50        | (SR)/(TR) | (SR)/(TR) | (SR)/(TR) |  SR/TR  |   (TR)    |   (TR)    |  (SR)/(TR)   |         |               |            (SR)            |
 
 ##### Chinese Naval Threats
 

--- a/src/stores/air_to_ground/missiles/shrike.md
+++ b/src/stores/air_to_ground/missiles/shrike.md
@@ -322,16 +322,16 @@ General Key:
 
 | Seeker       | Hawk  | Patriot | Rapier | Roland | NASAMS | IRIS-T SLM |
 | ------------ | :---: | :-----: | :----: | :----: | :----: | :--------: |
-| Mk 22        |  TR   |   STR   |   SR   |        |        |    STR     |
+| Mk 22        |  TR   |   STR   |   SR   |        |        |   (STR)    |
 | Mk 23        |  TR   |         |   SR   |        |        |            |
 | Mk 24 Mod 5  |  TR   |         |   SR   |        |        |            |
 | Mk 24 Mod 34 |  TR   |         |   SR   |        |        |            |
-| Mk 25        |  TR   |   STR   |  (SR)  |        |        |    STR     |
+| Mk 25        |  TR   |   STR   |  (SR)  |        |        |   (STR)    |
 | Mk 36        |  TR   |         |   SR   |   TR   |  (SR)  |            |
 | Mk 37        | SR/TR |         |   SR   |        |        |            |
 | Mk 49 Mod 0  |  TR   |         |   SR   |        |        |            |
 | Mk 49 Mod 1  |  TR   |         |   SR   |        |        |            |
-| Mk 50        |  TR   |   STR   |  (SR)  |        |        |    STR     |
+| Mk 50        |  TR   |   STR   |  (SR)  |        |        |   (STR)    |
 
 #### Naval Threats
 


### PR DESCRIPTION
- Added new CurrentHill SAMs (SA-15 Tor-M2, SA-22, both Project 22160s).