### PR TITLE
Added WIP to TGT/MSL switch (for Shrikes)

### DIFF
--- a/src/cockpit/pilot/pedestal_group.md
+++ b/src/cockpit/pilot/pedestal_group.md
@@ -137,7 +137,7 @@ For Shrikes, TGT/MSL REJ turns off the weapon seeker entirely until released.
 The DF REJ position selects the WRCS mode for receiving a solution, while the
 center position uses the weapon's own, less accurate seeker system instead.
 
-> 🚧 The TGT/MSL REJ switch functionality for Shrikes has not been fully implemented and is subject to change.
+> 🚧 Due to engine limitations the TGT/MSL REJ switch functionality for Shrikes is not available.
 
 ### Band Switch
 

--- a/src/cockpit/pilot/pedestal_group.md
+++ b/src/cockpit/pilot/pedestal_group.md
@@ -137,6 +137,8 @@ For Shrikes, TGT/MSL REJ turns off the weapon seeker entirely until released.
 The DF REJ position selects the WRCS mode for receiving a solution, while the
 center position uses the weapon's own, less accurate seeker system instead.
 
+> 🚧 The TGT/MSL REJ switch functionality for Shrikes has not been fully implemented and is subject to change.
+
 ### Band Switch
 
 ![pilot_shrike_tgt_reject](../../img/pilot_shrike_band.jpg)


### PR DESCRIPTION
Added note about TGT/MSL switch functionality not being fully implemented.

This is not mentioned in the manual, even in the Shrike Weapons Section, and will be updated there as well.