### PR TITLE
Add SAMSON Decoy entry to expanded stores table

### DIFF
--- a/src/stores/overview.md
+++ b/src/stores/overview.md
@@ -164,6 +164,7 @@ variant and might still be added in the future.
 | GBU-11                  |         |
 | GBU-12A                 |         |
 | GBU-15                  | DMAS    |
+| SAMSON Decoy            |         |
 | MXU-658 Travel Pod      |         |
 | ALQ-101                 |         |
 | ALQ-119                 |         |


### PR DESCRIPTION

<img width="850" height="567" alt="image" src="https://github.com/user-attachments/assets/df5f7ed5-ea6e-4d36-95d2-270c0fc27b60" />

**Copied from Discord**
I was recently shown the list of stores known to be used on our F-4E variant and potentially being considered for later introduction.
I'd like to submit the SAMSON decoy as an under-appreciated tool in the F-4E's arsenal, both for completeness of that list and in hope that one day we might get it in-game.

**What is/was it:**
A direct ancestor of TALD, SAMSON was a product of the defence division of Brunswick Corp out of the USA with the primary customer being Isreal for the A-4 and F-4, with the US Navy an early adopter on the American side.
The Phantom proved able to loft SAMSON decoys over 20nm from low altitudes in the Bekaa Valley, which convinced the USA that it was worth sacrificing valuable pylon space on strike platforms to carry air-launched decoys.

This would later result in the US funding an improved version, the TALD, which was built on a larger, boxier airframe with the space to add chaff launchers etc.
Brunswick second sourced production of SAMSON and later TALD to IMI in Israel, which would bite them when the US selected IMI (called TAAS at that point) to produce all their TALDS after 1992.

**How was it employed:**
 - It could be employed in level flight like a TALD, with the wings snapping open immediately.
 - It could also be lofted. SAMSON had a pressure switch so it could also be set up to deploy the wings after it started to lose altitude (like how the shrike waits to start guidance in LOFT mode). That gave it extra range when used in low altitude loft attacks by minimising drag.

SAMSON required no special interfaces, and was deployed like any other dumb bomb.

There was a Luneberg lens behind the radome on the front to increase passive RCS, and a battery powered amplifier that repeated incoming signals.
It could be made to carry out pre-programmed series of manoeuvres, but this was not guidance just a way to make the decoy look more convincing on radar.

**What would be needed to add it in DCS:**
 - In DCS the TALD doesn't have the ability to do its deception manoeuvres modelled so I can't see anyone complaining if the same was true for SAMSON.
 - We'd need a new model with animated pop-out wings (also the lugs flip down flush with the fuselage seemingly unlike on the TALD).
 - Frankly I feel the weapon and flight model code for the TALD could almost (with permission) be copied wholesale, with the exception of needing fusing options for DIRECT/LOFT deployment of the wings. That would give a pretty faithful representation of the decoy, certainly as good as we could reasonably expect in DCS.
 
<img width="850" height="567" alt="image" src="https://github.com/user-attachments/assets/b41b9536-da4f-499a-ac3b-fa36ae97e6f0" />
<img width="850" height="567" alt="image" src="https://github.com/user-attachments/assets/c5082ced-26f3-4682-b5e1-eb01807caac1" />
